### PR TITLE
Add YouTube link support for audio extraction

### DIFF
--- a/build_exe.ps1
+++ b/build_exe.ps1
@@ -42,6 +42,7 @@ try {
         "--windowed",
         "--name","SpeedTake",
         "--add-binary","$ffmpegPath;.",
+        "--hidden-import","yt_dlp",
         $EntryPoint
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ttkbootstrap
+yt-dlp


### PR DESCRIPTION
## Summary
- store selected inputs as structured records so the picker can mix video files and URLs
- add a YouTube link workflow that validates URLs, downloads audio with yt-dlp, and cleans up temporary files during extraction
- bundle the new dependency for Windows builds and document it in requirements

## Testing
- python -m compileall audio.py

------
https://chatgpt.com/codex/tasks/task_e_68dc5ea5941883219c400c8575f0ded7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Import audio from YouTube via a new “Add YouTube Link” button with URL validation.
  - Automatic YouTube audio download with clear progress and error messages.
  - Process mixed inputs (local files and YouTube links) seamlessly.
  - Optional output directory support with automatic folder creation.
  - Improved per-item status updates and robust error handling with cleanup.

- Chores
  - Added yt-dlp as a dependency.
  - Updated build script to bundle yt-dlp into the executable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->